### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Rust-WASM-Project"
 version = "0.1.0"
-edition = "2022"
+edition = "2021"
 
 [workspace]
 


### PR DESCRIPTION
Downgrading the Rust and Cargo version from `2022` to `2021` to solve compatibility issues